### PR TITLE
Removed unnecessary 'hide' class from loading container

### DIFF
--- a/src/resources/views/home.blade.php
+++ b/src/resources/views/home.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.master')
 
 @section('content')
-    <div class="loading-container hide" id="loading">
+    <div class="loading-container" id="loading" style="display: none;">
         <div class="loading">
             <img src="{{ asset('lib/images/loading.svg') }}" alt="Loading..." class="img-fluid" width="150">
         </div>


### PR DESCRIPTION
Fixing a stupid mistake I made, should ensure the loading icon is centered correctly.