### PR TITLE
Fixed columns not being filled in `atis_audio_files` table

### DIFF
--- a/src/app/Http/Controllers/API/TextToSpeechController.php
+++ b/src/app/Http/Controllers/API/TextToSpeechController.php
@@ -183,6 +183,12 @@ class TextToSpeechController extends Controller
             $atis_file->atis = $atis;
             $atis_file->zulu = $zulu;
             $atis_file->file_name = $name;
+            $atis_file->storage_location = env('FILESYSTEM_DRIVER', 'local');
+            if (strpos($atis, 'AUTOMATED WEATHER OBSERVATION') !== false) {
+                $atis_file->output_type = 'AWOS';
+            } else {
+                $atis_file->output_type = 'ATIS';
+            }
             $atis_file->save();
 
             $file_id = $atis_file->id;


### PR DESCRIPTION
- Set storage location column based on FILESYSTEM_DRIVER environment variable
- Set output type column based on the presence of "AUTOMATED WEATHER OBSERVATION" in the ATIS string.