### PR TITLE
Bug fixes and improvements in bug_report.yml template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,10 @@ body:
       label: Version
       description: What version of our code are you running?
       options:
-        - 2.2.3 (latest)
+        - 2.2.6 (latest)
+        - 2.2.5
+        - 2.2.4
+        - 2.2.3
         - 2.2.2
         - 2.2.1
         - 2.2.0
@@ -41,6 +44,7 @@ body:
         - 2.1.0
         - 2.0.7
         - 2.0.6 (legacy)
+        - Other
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,8 +2,6 @@ name: Bug Report
 description: File a bug report
 title: "[Bug]: "
 labels: ["bug", "triage"]
-assignees:
-  - Codycody31
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,7 +68,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/Codycody31/ATIS_GENERATOR/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/VMGWARE/vATCSuite/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true


### PR DESCRIPTION
This pull request includes multiple bug fixes and improvements in the bug_report.yml template. It updates the latest version option to 2.2.6 and adds previous versions 2.2.5, 2.2.4, 2.2.3, and 2.2.2. Additionally, it corrects the link to the Code of Conduct and removes the assignees field to allow for dynamic assignment based on project settings.